### PR TITLE
remove unused ecosystem_id parameter

### DIFF
--- a/ebiose/cloud_client/ebiose_api_client.py
+++ b/ebiose/cloud_client/ebiose_api_client.py
@@ -321,9 +321,8 @@ class EbioseAPIClient:
 
     @classmethod
     @_handle_api_errors
-    def select_agents(cls, ecosystem_id:str, nb_agents:int, forge_cycle_uuid: str) -> list["Agent"]:
+    def select_agents(cls, nb_agents: int, forge_cycle_uuid: str) -> list["Agent"]:
         """Select agents from an ecosystem."""
-        # TODO(xabier): remove unused parameter ecosystem_id
         response = cls._client.select_agents_for_forge_cycle(
             forge_cycle_uuid=forge_cycle_uuid,
             nb_agents= 100, # nb_agents, # TODO(xabier): fix when server side is ready (then should at least filter on agent_type==None)

--- a/ebiose/core/forge_cycle.py
+++ b/ebiose/core/forge_cycle.py
@@ -193,7 +193,6 @@ class ForgeCycle:
         selected_agents = []
         if self.config.mode == "cloud":
             selected_agents = EbioseAPIClient.select_agents(
-                ecosystem_id=ecosystem.id,
                 nb_agents=n_selected_agents,
                 forge_cycle_uuid=self.id,
             )


### PR DESCRIPTION
File: /ebiose/cloud_client/ebiose_api_client.py (Line 326)

Current Problem: The ecosystem_id parameter is not used but is still present in the method signature.

Solution Needed: Remove the unused ecosystem_id parameter from the method signature and any calls to the method.

Context: This is in a method that was likely refactored but the parameter wasn't cleaned up.

Impact: Unused parameters create confusion and make the API unclear.

Closes #58 